### PR TITLE
Updated naming, unit of measure, icon, bumped omnilogic.py to 0.3.4

### DIFF
--- a/homeassistant/components/omnilogic/__init__.py
+++ b/homeassistant/components/omnilogic/__init__.py
@@ -1,23 +1,16 @@
 """The Omnilogic integration."""
 import asyncio
-import json
-import logging
 from datetime import timedelta
+import logging
 
-import async_timeout
-from homeassistant.exceptions import ConfigEntryNotReady
-
-
-import aiohttp
 from omnilogic import OmniLogic
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import DOMAIN
 
@@ -42,7 +35,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     password = conf[CONF_PASSWORD]
 
     async def async_update_data():
-        """Fetch data from API endpoint"""
+        """Fetch data from API endpoint."""
         api = OmniLogic(username, password)
         data = await api.get_telemetry_data()
         await api.close()

--- a/homeassistant/components/omnilogic/config_flow.py
+++ b/homeassistant/components/omnilogic/config_flow.py
@@ -1,7 +1,6 @@
 """Config flow for Omnilogic integration."""
 import logging
 
-from omnilogic import OmniLogic
 import voluptuous as vol
 
 from homeassistant import config_entries, core, exceptions

--- a/homeassistant/components/omnilogic/manifest.json
+++ b/homeassistant/components/omnilogic/manifest.json
@@ -3,7 +3,7 @@
   "name": "Hayward Omnilogic",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/omnilogic",
-  "requirements": ["omnilogic==0.3.1"],
+  "requirements": ["omnilogic==0.3.4"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/homeassistant/components/omnilogic/sensor.py
+++ b/homeassistant/components/omnilogic/sensor.py
@@ -1,22 +1,44 @@
+"""Definition and setup of the Omnilogic Sensors for Home Assistant."""
+
 from datetime import timedelta
 import logging
 
-from homeassistant.const import TEMP_FAHRENHEIT, UNIT_PERCENTAGE
+from homeassistant.components.sensor import ENTITY_ID_FORMAT
+from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT, UNIT_PERCENTAGE
 from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN
 
+TEMP_UNITS = [TEMP_CELSIUS, TEMP_FAHRENHEIT]
 PERCENT_UNITS = [UNIT_PERCENTAGE, UNIT_PERCENTAGE]
 SALT_UNITS = ["g/L", "PPM"]
 
 SENSORS = [
-    ("pool_temperature", "Pool Temperature", "temperature", TEMP_FAHRENHEIT),
-    ("air_temperature", "Air Temperature", "temperature", TEMP_FAHRENHEIT),
-    ("spa_temperature", "Spa Temperature", "temperature", TEMP_FAHRENHEIT),
-    ("pool_chlorinator", "Pool Chlorinator", PERCENT_UNITS, "mdi:gauge"),
-    ("spa_chlorinator", "Spa Chlorinator", PERCENT_UNITS, "mdi:gauge"),
-    ("salt_level", "Salt Level", SALT_UNITS, "mdi:gauge"),
-    ("pump_speed", "Pump Speed", PERCENT_UNITS, "mdi:speedometer"),
+    (
+        "pool_temperature",
+        "Pool Temperature",
+        "temperature",
+        "mdi:thermometer",
+        TEMP_UNITS,
+    ),
+    (
+        "air_temperature",
+        "Air Temperature",
+        "temperature",
+        "mdi:thermometer",
+        TEMP_UNITS,
+    ),
+    (
+        "spa_temperature",
+        "Spa Temperature",
+        "temperature",
+        "mdi:thermometer",
+        TEMP_UNITS,
+    ),
+    ("pool_chlorinator", "Pool Chlorinator", "none", "mdi:gauge", PERCENT_UNITS),
+    ("spa_chlorinator", "Spa Chlorinator", "none", "mdi:gauge", PERCENT_UNITS),
+    ("salt_level", "Salt Level", "none", "mdi:gauge", SALT_UNITS),
+    ("pump_speed", "Pump Speed", "none", "mdi:speedometer", PERCENT_UNITS),
 ]
 
 SCAN_INTERVAL = timedelta(seconds=30)
@@ -33,25 +55,42 @@ async def async_setup_entry(hass, entry, async_add_entities, discovery_info=None
 
             sensors = [
                 OmnilogicSensor(
-                    coordinator, kind, name, backyard, bow, device_class, unit
+                    coordinator, kind, name, backyard, bow, device_class, icon, unit
                 )
-                for kind, name, device_class, unit in SENSORS
+                for kind, name, device_class, icon, unit in SENSORS
             ]
     async_add_entities(sensors, update_before_add=True)
 
 
 class OmnilogicSensor(Entity):
-    """Defines an Omnilogic sensor entity"""
+    """Defines an Omnilogic sensor entity."""
 
-    def __init__(self, coordinator, kind, name, backyard, bow, icon, unit):
+    def __init__(
+        self, coordinator, kind, name, backyard, bow, device_class, icon, unit
+    ):
+        """Initialize Entities."""
+        sensorname = (
+            "omni_"
+            + backyard["BackyardName"].replace(" ", "_")
+            + "_"
+            + bow["Name"].replace(" ", "_")
+            + "_"
+            + kind
+        )
         self._kind = kind
-        self._name = name
+        self._name = None
+        self.entity_id = ENTITY_ID_FORMAT.format(sensorname)
         self._backyard = backyard
         self._backyardName = backyard["BackyardName"]
         self._state = None
-        self._unit = unit
+        self._unit_type = backyard["Unit-of-Measurement"]
+        self._device_class = device_class
+        self._icon = icon
         self._bow = bow
+        self._unit = None
         self.coordinator = coordinator
+        self.attrs = {}
+        self.attrs["MspSystemId"] = backyard["systemId"]
 
     @property
     def should_poll(self) -> bool:
@@ -62,12 +101,34 @@ class OmnilogicSensor(Entity):
     def unique_id(self) -> str:
         """Return a unique, Home Assistant friendly identifier for this entity."""
         # need a more unique id
-        return self._backyardName + "." + self._name
+        return self.entity_id
 
     @property
     def name(self) -> str:
         """Return the name of the entity."""
         return self._name
+
+    @property
+    def device_class(self):
+        """Return the device class of the entity."""
+        if self._device_class != "none":
+            return self._device_class
+
+    @property
+    def unit_of_measurement(self):
+        """Return the right unit of measure."""
+        return self._unit
+
+    @property
+    def icon(self):
+        """Return the icon for the entity."""
+        return self._icon
+
+    @property
+    def device_state_attributes(self):
+        """Return the attributes."""
+
+        return self.attrs
 
     @property
     def force_update(self):
@@ -76,7 +137,7 @@ class OmnilogicSensor(Entity):
 
     @property
     def state(self):
-
+        """Return the state."""
         return self._state
 
     async def async_update(self):
@@ -84,21 +145,80 @@ class OmnilogicSensor(Entity):
         await self.coordinator.async_request_refresh()
 
         if self._kind == "pool_temperature":
-            self._state = self.coordinator.data[0]["BOWS"][0].get("waterTemp")
+            temp_return = float(self.coordinator.data[0]["BOWS"][0].get("waterTemp"))
+            unit_of_measurement = TEMP_FAHRENHEIT
+            if self.coordinator.data[0]["Unit-of-Measurement"] == "Metric":
+                temp_return = round((temp_return - 32) * 5 / 9, 1)
+                unit_of_measurement = TEMP_CELSIUS
+
+            self.attrs["hayward_temperature"] = temp_return
+            self.attrs["hayward_unit_of_measure"] = unit_of_measurement
+            self._state = float(self.coordinator.data[0]["BOWS"][0].get("waterTemp"))
+            self._unit = TEMP_FAHRENHEIT
+            self.attrs["SystemId"] = self.coordinator.data[0]["BOWS"][0].get("systemId")
+            self._name = (
+                self.coordinator.data[0]["BOWS"][0].get("Name") + " Water Temperature"
+            )
+
         elif self._kind == "pump_speed":
             self._state = self.coordinator.data[0]["BOWS"][0]["Filter"].get(
                 "filterSpeed"
             )
-        elif self._kind == "salt_level":
-            self._state = self.coordinator.data[0]["BOWS"][0]["Chlorinator"].get(
-                "avgSaltLevel"
+            self._unit = "%"
+            self._name = (
+                self.coordinator.data[0]["BOWS"][0].get("Name")
+                + " "
+                + self.coordinator.data[0]["BOWS"][0]["Filter"].get("Name")
             )
+        elif self._kind == "salt_level":
+            salt_return = float(
+                self.coordinator.data[0]["BOWS"][0]["Chlorinator"].get("avgSaltLevel")
+            )
+            unit_of_measurement = "ppm"
+
+            if self.coordinator.data[0]["Unit-of-Measurement"] == "Metric":
+                salt_return = round(salt_return / 1000, 2)
+                unit_of_measurement = "g/L"
+
+            self._state = salt_return
+            self._unit = unit_of_measurement
+            self.attrs["SystemId"] = self.coordinator.data[0]["BOWS"][0][
+                "Chlorinator"
+            ].get("systemId")
+            self._name = (
+                self.coordinator.data[0]["BOWS"][0].get("Name")
+                + " "
+                + self.coordinator.data[0]["BOWS"][0]["Chlorinator"].get("Name")
+                + " Salt Level"
+            )
+
         elif self._kind == "pool_chlorinator":
             self._state = self.coordinator.data[0]["BOWS"][0]["Chlorinator"].get(
                 "Timed-Percent"
             )
+            self._unit = "%"
+            self._name = (
+                self.coordinator.data[0]["BOWS"][0].get("Name")
+                + " "
+                + self.coordinator.data[0]["BOWS"][0]["Chlorinator"].get("Name")
+                + " Setting"
+            )
+
         elif self._kind == "air_temperature":
-            self._state = self.coordinator.data[0].get("airTemp")
+            temp_return = float(self.coordinator.data[0].get("airTemp"))
+            unit_of_measurement = TEMP_FAHRENHEIT
+            if self.coordinator.data[0]["Unit-of-Measurement"] == "Metric":
+                temp_return = round((temp_return - 32) * 5 / 9, 1)
+                unit_of_measurement = TEMP_CELSIUS
+
+            self.attrs["hayward_temperature"] = temp_return
+            self.attrs["hayward_unit_of_measure"] = unit_of_measurement
+            self._state = float(self.coordinator.data[0].get("airTemp"))
+            self._unit = TEMP_FAHRENHEIT
+            self.attrs["SystemId"] = self.coordinator.data[0]["BOWS"][0].get("systemId")
+            self._name = (
+                self.coordinator.data[0]["BOWS"][0].get("Name") + " Air Temperature"
+            )
 
     async def async_added_to_hass(self):
         """Subscribe to updates."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -987,7 +987,7 @@ oauth2client==4.0.0
 oemthermostat==1.1
 
 # homeassistant.components.omnilogic
-omnilogic==0.1.8
+omnilogic==0.3.4
 
 # homeassistant.components.onkyo
 onkyo-eiscp==1.2.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -455,7 +455,7 @@ numpy==1.19.0
 oauth2client==4.0.0
 
 # homeassistant.components.omnilogic
-omnilogic==0.1.8
+omnilogic==0.3.4
 
 # homeassistant.components.onvif
 onvif-zeep-async==0.4.0


### PR DESCRIPTION
Updated entity ids, updated unit of measure, updated icon, bumped omnilogic.py to 0.3.4, fixed commit errors

Also added system attributes for MspSystemId and the temperature in the units defined in the Omnilogic system for those of us who like to use F instead of C for our pools (when HA will automatically override that conversion).

Tested in venv working on my end.

New entity ids follow:  

sensor.omni_systemname_poolname_sensorname (with underscores to replace spaces)

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
